### PR TITLE
Fix links and add space between image and label

### DIFF
--- a/solana/solana-wallet/wallet-tutorial-conclusion.md
+++ b/solana/solana-wallet/wallet-tutorial-conclusion.md
@@ -21,7 +21,8 @@ The opportunities are endless and we wish you well on your journey!
 _If you want to connect with an amazing community of developers, join us on [Discord](https://discord.gg/fszyM7K)._
 
 
-![Figure 10: This is just the beginning, godspeed!](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/begin.jpeg)
+![Figure 10: This is just the beginning, godspeed!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/begin.jpeg)
+
 {% label %}
 Figure 10: This is just the beginning, godspeed!
 

--- a/solana/solana-wallet/wallet-tutorial-intro.md
+++ b/solana/solana-wallet/wallet-tutorial-intro.md
@@ -10,7 +10,8 @@ We think of ourselves as your guide - for a brief amount of time - on your journ
 
 We've tried to show you the door (or maybe part of it). Your job is to discover your path and walk it courageously.
 
-![Figure 1: You take the red pill — you stay in Wonderland and I show you how deep the rabbit hole goes](./assets/cat.jpeg)
+![Figure 1: You take the red pill — you stay in Wonderland and I show you how deep the rabbit hole goes](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/cat.jpeg)
+
 {% label %}
 Figure 1: You take the red pill — you stay in Wonderland and I show you how deep the rabbit hole goes
 
@@ -70,6 +71,7 @@ Finally, we'll use the phrase we generated in [Step 2](https://learn.figment.io/
 
 Although building a production-ready, non-custodial wallet like [Phantom](https://phantom.app/) or [MetaMask](https://metamask.io/) is beyond the scope of this tutorial, by the end of it you'll have developed a foundation of judgment that will let you better allocate your learning time as you explore new projects. To assist with that, we'll end the tutorial with a list of [additional resources](https://learn.figment.io/tutorials/solana-wallet-conclusion#additional-resources) that you'll be well prepared to explore.
 
-![Figure 2: A journey of a thousand miles begins with a single step](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/journey.jpeg)
+![Figure 2: A journey of a thousand miles begins with a single step](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/journey.jpeg)
+
 {% label %}
 Figure 2: A journey of a thousand miles begins with a single step

--- a/solana/solana-wallet/wallet-tutorial-step-2.md
+++ b/solana/solana-wallet/wallet-tutorial-step-2.md
@@ -4,7 +4,8 @@ Crypto wallets are the most critical piece of user-facing infrastructure in the 
 
 A wallet is less like the wallet you use for your credit cards, and a lot more like a keychain. If you think of a blockchain as a giant bank safe with digital safety deposit boxes, wallets are the keychains where you keep the key to your box. Once you have access to a box, you can manage the contents of it by receiving, sending, holding and spending digital assets.
 
-![Figure 3: Wallets hold private keys to your public address on a blockchain](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/safe.jpeg)
+![Figure 3: Wallets hold private keys to your public address on a blockchain](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/safe.jpeg)
+
 {% label %}
 Figure 3: Wallets hold private keys to your public address on a blockchain
 

--- a/solana/solana-wallet/wallet-tutorial-step-3.md
+++ b/solana/solana-wallet/wallet-tutorial-step-3.md
@@ -10,7 +10,8 @@ We'll be connecting to one of Solana's networks, and fetching the balance for th
 
 The concept of various networks for a single protocol is similar to that of different environments for an app (e.g. development, test, production, etc). Typically blockchain protocols have a main network or mainnet, which refers to the production blockchain with real economic value and official transactions, and at least one experimentation network, which refers to an identical blockchain used to test features before they go live on mainnet.
 
-![Figure 4: It's always important to test on devnet before deploying on mainnet](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/consultant.jpeg)
+![Figure 4: It's always important to test on devnet before deploying on mainnet](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/consultant.jpeg)
+
 {% label %}
 Figure 4: It's always important to test on devnet before deploying on mainnet
 

--- a/solana/solana-wallet/wallet-tutorial-step-4.md
+++ b/solana/solana-wallet/wallet-tutorial-step-4.md
@@ -7,7 +7,8 @@ You might be wondering whether we'll now need to transfer real money so we can t
 In this step, we'll be building functionality to allow users to "airdrop" SOL tokens into their devnet account. In the crypto world, an airdrop is a way for the protocol to distribute tokens to account holders for free. 
 
 
-![Figure 5: We're about reinforce our supply lines with some devnet SOL](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/airdrop.jpeg)
+![Figure 5: We're about reinforce our supply lines with some devnet SOL](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/airdrop.jpeg)
+
 {% label %}
 Figure 5: We're about reinforce our supply lines with some devnet SOL
 
@@ -35,7 +36,8 @@ Following our previous heuristic of searching the docs for keywords, we can now 
 
 You might be wondering what a "lamport" is. Solana's native token, SOL, is divisible into 1 billion lamports. You can think of lamports as the cents to SOL's dollar.
 
-![Figure 6: This is also a lamport. Leslie Lamport is the lamport's namesake. He's a computer scientist who has made key contributions to distributed systems](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/leslie.jpeg)
+![Figure 6: This is also a lamport. Leslie Lamport is the lamport's namesake. He's a computer scientist who has made key contributions to distributed systems](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/leslie.jpeg)
+
 {% label %}
 Figure 6: This is also a lamport. Leslie Lamport is the lamport's namesake. He's a computer scientist who has made key contributions to distributed systems
 
@@ -80,7 +82,8 @@ Avid readers might have noticed that the balance in our account looks wrong. It 
 return balance / LAMPORTS_PER_SOL;
 ```
 
-![Figure 7: Getting close to the summit](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/climbing.jpeg)
+![Figure 7: Getting close to the summit](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/climbing.jpeg)
+
 {% label %}
 Figure 7: Getting close to the summit
 

--- a/solana/solana-wallet/wallet-tutorial-step-5.md
+++ b/solana/solana-wallet/wallet-tutorial-step-5.md
@@ -10,7 +10,8 @@ But there's one more important component: we need to prove to the network that w
 
 Consider a traditional paper check that you might use to pay your landlord. The check has your name and address printed on the top left. It includes a field for you to write the recipient's name along with a field for you to write the amount you're paying. Finally, it includes a field for you to sign the check to validate to the bank that you're approving the transfer.
 
-![Figure 8: Crypto transactions are like digital checks (with real signatures)](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/check.jpeg)
+![Figure 8: Crypto transactions are like digital checks (with real signatures)](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/check.jpeg)
+
 {% label %}
 Figure 8: Crypto transactions are like digital checks (with real signatures)
 
@@ -134,7 +135,8 @@ Once you fill in the public address of your recipient and the amount, say one mi
 
 The [Solana Block Explorer](https://explorer.solana.com/?cluster=devnet) is a simple dashboard that allows you to search for specific blocks, accounts, transactions, contracts and tokens by network. It displays all the information related to the item you searched for.
 
-![Figure 9: Oh the places you'll go!](https://github.com/figment-networks/learn-tutorials/blob/master/solana/solana-wallet/assets/explore.jpeg)
+![Figure 9: Oh the places you'll go!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/solana/solana-wallet/assets/explore.jpeg)
+
 {% label %}
 Figure 9: Oh the places you'll go!
 


### PR DESCRIPTION
# Description
* Add a line between images and `{% label %}` tags so the parser can find them
* Change the image links to raw github content

# Result
* This PR fixes bugs that were causing the Solana Wallet Tutorial to not display images and to not display labels properly
