### PR TITLE
LEARN-27

### DIFF
--- a/mirror/00-mirror-intro.md
+++ b/mirror/00-mirror-intro.md
@@ -1,10 +1,10 @@
-# Blog Platform Tutorial
+Welcome to the Mirror Clone tutorial! The goal of this tutorial is to introduce the Web 3 development process in the context of a full stack decentralized application. Specifically, we’ll be bridging you from Web 2 to Web 3 by building a blog similar to [Mirror](https://mirror.xyz/) using a Web 3 stack.
+Mirror is a powerful Web 3 platform for publishing content. It allows writers to publish in a decentralized, censorship-resistant way while retaining full ownership of their content. It also enables functionality like tipping writers, splitting proceeds with co-writers and contributors, and crowdfunding projects. We’ll only be implementing the basics of publishing entries and minting their NFTs, but you’ll end up with a dApp that you can extend as you like.
+As you build, we’ll introduce key concepts to help you scaffold your mental model and start adding Web 3 skills into your toolbox.
 
-Welcome to the Blog Platform Tutorial. The goal of this tutorial is to introduce the Web 3 development process in the context of a full stack decentralized application. Specifically, we'll be bridging you from Web 2 to Web 3 by building a blog similar to [Mirror.xyz](https://mirror.xyz/) using a Web 3 stack. As you build, we'll introduce key concepts to help you scaffold your mental model and start adding Web 3 skills into your toolbox.
+# Prerequisites 🪜
 
-## Prerequisites 🪜
-
-If you know how to program and have [JavaScript](https://www.javascript.com/) experience, you'll be able to complete the tutorial. Having said that, you'll be more comfortable if you have some experience with [TypeScript](https://www.typescriptlang.org/), [React](https://reactjs.org/), and [Next.js](https://nextjs.org/). Moreover, while you may not have built full stack Web 3 applications before, hopefully you have used a crypto wallet like [MetaMask](https://metamask.io/) and you're familiar with basic blockchain concepts like public addresses, private keys, and signing transactions.
+If you know how to program and have [JavaScript](https://www.javascript.com/) experience, you'll be able to complete the tutorial. Having said that, you'll be more comfortable if you have some experience with [Typescript](https://www.typescriptlang.org/), [React](https://reactjs.org/), and [Next.js](https://nextjs.org/). Moreover, while you may not have built full stack Web 3 applications before, hopefully you have used a crypto wallet like [MetaMask](https://metamask.io/) and you're familiar with basic blockchain concepts like public addresses, private keys, and signing transactions.
 
 If any of that sounds unfamiliar, or the idea of engaging with those concepts sounds daunting at this point in your learning, we recommend starting with the [Solana Wallet](https://learn.figment.io/tutorials/solana-wallet-intro) tutorial before completing this one.
 
@@ -12,12 +12,12 @@ As always, we think of ourselves as your guide - for a brief amount of time - on
 
 We've tried to show you the door (or maybe part of it). Your job is to discover your path and walk it courageously.
 
-![Figure 1: “I do not believe it to be a matter of hope, it is simply a matter of time.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/matrix.jpeg?raw=true)
+![“I do not believe it to be a matter of hope, it is simply a matter of time.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/matrix.jpeg?raw=true)
 
 {% label %}
-Figure 1: “I do not believe it to be a matter of hope, it is simply a matter of time.”
+“I do not believe it to be a matter of hope, it is simply a matter of time.”
 
-## Tutorial Structure 🧱
+# Tutorial Structure 🧱
 
 The tutorial is structured as a set of steps that break down the development process into specific work blocks on each part of the stack. Each step discusses key concepts and mental models that create the necessary context for you to better understand what we're building and why. Think of this as the **warm up**.
 
@@ -25,27 +25,27 @@ After the warm up we provide a step-by-step implementation of the functionality,
 
 Finally, we **challenge** you to implement the feature on your own by providing just enough instructions. This allows you to exercise [active recall](https://en.wikipedia.org/wiki/Active_recall) and increases your ability to make connections.
 
-## Blog Preview 🖥
+# Blog Preview 🖥
 
-By the time you're done, you'll have a blog similar to [Mirror.xyz](https://mirror.xyz/). Users will be able to write posts, publish them, mint NFTs for each post, and transfer those NFTs to other public addresses.
+By the time you're done, you'll have a blog similar to [Mirror](https://mirror.xyz/). Users will be able to write entries, publish them, mint NFTs for each entry, and transfer those NFTs to other public addresses.
 
-The posts will be saved on [Arweave](https://www.arweave.org/), a decentralized storage solution for immutable data storage, and the NFTs will be [ERC-721](https://eips.ethereum.org/EIPS/eip-721) tokens on [Polygon](https://polygon.technology/), a protocol for scalable Ethereum dApps.
+The entries will be saved on [Arweave](https://www.arweave.org/), a decentralized storage solution for immutable data storage, and the NFTs will be [ERC-721](https://eips.ethereum.org/EIPS/eip-721) tokens on [Polygon](https://polygon.technology/), a protocol for scalable Ethereum dApps.
 
-Step 1 will walk you through some basic set up and configuration. This will include cloning a template repo, so you don't have to write code you're already familiar with (i.e. NextJS). It will also include setting up a few environment variables you'll need in later steps.
+**Step 1** will walk you through some basic set up and configuration. This will include cloning a template repo, so you don't have to write code you're already familiar with (i.e. NextJS). It will also include setting up a few environment variables you'll need in later steps.
 
-In Step 2, we'll introduce the [ethers.js](https://docs.ethers.io/) library and learn how to a user's MetaMask wallet to the dApp.
+In **Step 2**, we'll introduce the [ethers.js](https://docs.ethers.io/) library and learn how to a user's MetaMask wallet to the dApp.
 
 ![Screenshot of connecting wallet](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/connect.jpg?raw=true)
 
-Then we'll introduce [Arweave](https://www.arweave.org/) - a decentralized, censorship resistant storage solution - in Step 3. We'll write an endpoint to create blog posts and finish a form to submit them. In Step 4 we'll learn how to fetch them and in Step 5 we'll write code to display a list of the latest posts.
+Then we'll introduce [Arweave](https://www.arweave.org/) - a decentralized, censorship resistant storage solution - in **Step 3**. We'll write an endpoint to create blog entries and finish a form to submit them. In **Step 4** we'll learn how to fetch them and in **Step 5** we'll write code to display a list of the latest entries.
 
-![Screenshot displaying a list of posts](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/posts.jpg?raw=true)
+![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/entries.jpg?raw=true)
 
-Step 6 will be a brief introduction to smart contracts including inheriting from standard libraries, writing functions, testing them and deploying the smart contract to the Polygon testnet. We'll be minting an NFT for each post so authors can own their posts.
+**Step 6** will be a brief introduction to smart contracts including inheriting from standard libraries, writing functions, testing them and deploying the smart contract to the Polygon testnet. We'll be minting an NFT for each entry so authors can own their entries.
 
 ![Screenshot of NFT](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/nft.jpg?raw=true)
 
-Finally, Step 7 will implement functionality that allows authors to transfer NFTs. This sets up the application for expansion into a marketplace for blog post ownership.
+Finally, **Step 7** will implement functionality that allows authors to transfer NFTs. This sets up the application for expansion into a marketplace for blog entry ownership.
 
 ![Screenshot of transfer](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/transfer.jpg?raw=true)
 
@@ -57,7 +57,7 @@ At the end of the tutorial, we'll include a few [additional resources](https://l
 
 Let's get started!
 
-![Figure 2: All big things come from small beginnings](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/ladder.jpeg?raw=true)
+![All big things come from small beginnings](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/ladder.jpeg?raw=true)
 
 {% label %}
-Figure 2: All big things come from small beginnings
+All big things come from small beginnings

--- a/mirror/00-mirror-intro.md
+++ b/mirror/00-mirror-intro.md
@@ -1,3 +1,5 @@
+# Welcome 👋
+
 Welcome to the Mirror Clone tutorial! The goal of this tutorial is to introduce the Web 3 development process in the context of a full stack decentralized application. Specifically, we’ll be bridging you from Web 2 to Web 3 by building a blog similar to [Mirror](https://mirror.xyz/) using a Web 3 stack.
 Mirror is a powerful Web 3 platform for publishing content. It allows writers to publish in a decentralized, censorship-resistant way while retaining full ownership of their content. It also enables functionality like tipping writers, splitting proceeds with co-writers and contributors, and crowdfunding projects. We’ll only be implementing the basics of publishing entries and minting their NFTs, but you’ll end up with a dApp that you can extend as you like.
 As you build, we’ll introduce key concepts to help you scaffold your mental model and start adding Web 3 skills into your toolbox.

--- a/mirror/01-mirror-setup.md
+++ b/mirror/01-mirror-setup.md
@@ -1,8 +1,6 @@
-# Step 1: Template and Configuration
-
 You'll be building the blog application on top of a [Next.js](https://nextjs.org/) template that we have pre-built. This way you can quickly scaffold your way into developing the Web 3 dApp with minimal configuration.
 
-## Setting Up 🧑‍💻
+# Setting Up 🧑‍💻
 
 Make sure you have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Node](https://nodejs.org/en/) and [yarn](https://yarnpkg.com/getting-started/install) installed. Make sure you've setup [SSH or token-based authentication](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) for Github. Then clone the repo and run the yarn command to install the app dependencies:
 
@@ -12,7 +10,7 @@ $ cd web3-evm-template
 $ yarn
 ```
 
-If you into any Node issues, make sure you're running version 14.17.0 or greater. You can use the [Node Version Manager](https://github.com/nvm-sh/nvm) if you need to manage multiple Node versions locally.
+If you run into any Node issues, make sure you're running version 14.17.0 or greater. You can use the [Node Version Manager](https://github.com/nvm-sh/nvm) if you need to manage multiple Node versions locally.
 
 Now that you have the template, you need to navigate to this tutorial's branch:
 
@@ -20,13 +18,13 @@ Now that you have the template, you need to navigate to this tutorial's branch:
 $ git checkout mirror-clone
 ```
 
-Next, you'll need to copy the example environment file `.env.local.example` to set the environment variables we'll need to write and deploy the smart contract. 
+Next, you'll need to copy the example environment file `.env.local.example` to set the environment variables needed to write and deploy the smart contract with Hardhat. 
 
 ```text
 $ cp .env.local.example .env.local
 ```
 
-Navigate to `.env.local` and set the four environment variables based on the instructions included below.
+Now open the file `.env.local` and set the four environment variables based on the instructions included below. If you are not familiar with them, [read more about the dotenv package and `.env` files](https://docs.figment.io/network-documentation/extra-guides/dotenv-and-.env).
 
 ```text
 ETHERSCAN_API_KEY=Polygonscan API Key. Go to https://polygonscan.com/login and login or create an account. Then click on API-KEYs on the left navigation panel to create an api key. Name the app MirrorClone. Copy-paste the API key here.
@@ -39,7 +37,7 @@ PRIVATE_KEY=Your private key exported from MetaMask. Go to https://metamask.zend
 [MetaMask](https://metamask.io/) is a crypto wallet built as a browser extension that allows you to interact with Ethereum and Ethereum-compatible blockchains as well as dApps built on top of them.
 
 {% hint style="warning" %}
-The **private key** environment variable is required to deploy the smart contract in Step 6. Despite the fact that the `.env.local` file has been placed in `.gitignore` already so you don't expose your private key, we still recommend you create a wallet whose sole purpose is its use in tutorials and local development. That way, you can mitigate the risk of exposing your wallet's private key.
+The **private key** environment variable is required to deploy the smart contract in Step 6. Despite the fact that the `.env.local` file has been placed in `.gitignore` already so you don't expose your private key, we still recommend you create a wallet specifically for use in tutorials and local development. That way, you can mitigate the risk of exposing your wallet's private key.
 {% endhint %}
 
 Finally, we want to add certain libraries that will set us up for smart contract development in Step 6 but without which we'll get a few compiling errors.
@@ -54,19 +52,19 @@ With that in place, our dApp template is ready to be built into a functional blo
 $ yarn dev
 ```
 
-## Reviewing the Template 🧐
+# Reviewing the Template 🧐
 
 Before we dive into the code, we should understand what the template comes with. Along with the standard folder structure and dependencies found in most NextJS applications, we have added two Web 3-specific libraries that we'll leverage throughout the tutorial - [ethers.js](https://docs.ethers.io/) and [Hardhat](https://hardhat.org/).
 
 Ethers is a JavaScript library designed to interact with Ethereum and Ethereum-compatible blockchains. We'll first encounter ethers in Step 2 to interface with MetaMask and connect our wallet.
 
-Hardhat is a development environment for Ethereum and Ethereum-compatible blockchains. It allows you to write and compile Solidity locally, run tests, and deploy smart contracts, all while fully supporting TypeScript. We'll leverage Hardhat in Step 6 to manage development of the smart contract used to mint and transfer NFTs related to blog posts.
+Hardhat is a development environment for Ethereum and Ethereum-compatible blockchains. It allows you to write and compile Solidity locally, run tests, and deploy smart contracts, all while fully supporting Typescript. We'll leverage Hardhat in Step 6 to manage development of the smart contract used to mint and transfer NFTs related to blog entries.
 
 Feel free to explore the rest of the template. It includes standard hooks and components that we'll leverage to add functionality to our blog. But that's enough set up for now.
 
 Let's build!
 
-![Figure 3: “I can feel the anticipation.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/lego.jpeg?raw=true)
+![“I can feel the anticipation.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/lego.jpeg?raw=true)
 
 {% label %}
-Figure 3: “I can feel the anticipation.”
+“I can feel the anticipation.”

--- a/mirror/02-connect-wallet.md
+++ b/mirror/02-connect-wallet.md
@@ -1,5 +1,3 @@
-# Step 2: Connecting a Wallet
-
 The first step for any dApp is setting up a way to connect to a user's wallet. This allows the dApp to authenticate the user without using traditional passwords. More importantly, this will allow the dApp to pull the user's onchain data so we can build user-specific dApp experiences.
 
 {% sidenote title="Box 2.1: A note on crypto wallets" %}
@@ -9,13 +7,13 @@ In this case, we'll be using a JavaScript library called [ethers.js](https://doc
 
 # Implementation 🧩
 
-The first step in performing any blockchain operation is typically instantiating a connection. This can be done by leveraging the **Providers** class in ethers.js. A Web 3 provider object includes functionality to read from a protocol.
+The first step in performing any blockchain operation is typically instantiating a connection. This can be accomplished with the **Providers** class in ethers.js. A Web 3 provider object includes functionality to read from a protocol.
 
-If you're familiar with React development, you can probably guess that we'll need a way to preserve application state after we connect to the wallet. That way we don't have to make the user re-connect their wallet with every render. For this we'll use React's [Context](https://reactjs.org/docs/context.html).
+If you're familiar with React development, you can probably guess that we'll need a way to preserve application state after we connect to the wallet. That way we don't have to make the user re-connect their wallet every time the page is rendered. For this, we'll use React's [Context](https://reactjs.org/docs/context.html).
 
 There are several ways to implement this, but in our case we'll be using a context provider (not to be confused with the Web 3 provider!) we built into our template in `context/web3Context.tsx`. 
 
-If we look at the Web3Provider function, we notice we're leveraging a simple implementation with ethers.js using **Web3Provider**:
+If we look at the Web3Provider function, notice we're using a simple implementation with the ethers.js **Web3Provider**:
 
 ```javascript
 const provider =
@@ -24,11 +22,11 @@ const provider =
       : new ethers.providers.Web3Provider(window.ethereum);
 ```
 
-If we focus on the last line, we notice that we're instantiating a provider based on `window.ethereum`. That object comes [courtesy of MetaMask](https://docs.metamask.io/guide/ethereum-provider.html), so we can pass it in as an argument to instantiate our Web 3 provider object. The rest of the code is simply checking whether the MetaMask extension is present so the dApp still runs even if there isn't one. 
+Focusing on the last line, notice that we're instantiating a provider based on `window.ethereum`. That object comes [courtesy of MetaMask](https://docs.metamask.io/guide/ethereum-provider.html), so we can pass it in as an argument to instantiate our Web 3 provider object. The rest of the code is simply checking whether the MetaMask extension is present, so the dApp still runs even if there isn't one. 
 
-Once we have a Web 3 provider, we can leverage the send method to request the accounts associated with the wallet we want to connect. Then, we can instantiate a **Signer** object that will give us access to functions that allow us to change the state of the blockchain.
+Once we have a Web 3 provider, we can use the `send` method to request the accounts associated with the wallet we want to connect. Then we can instantiate a **Signer** object that will give us access to functions that allow us to change the state of the blockchain.
 
-In our case, we have a connect function that first checks whether a provider is present, and then should get our user's public address and set it in state. If the user doesn't have MetaMask installed, it should alert them to install it.
+In our case, we have a `connect` function that first checks whether a provider is present, and then should get our user's public address and set it in state. If the user doesn't have MetaMask installed, it should alert them to install it.
 
 We can complete this function with three simple lines. First we need to request the accounts available in the MetaMask provider. Then we need to instantiate a signer that will allow us to get the address.
 
@@ -41,12 +39,12 @@ const address = await signer.getAddress();
 {% sidenote title="Box 2.2: Without centralized servers, what are we connecting to?" %}
 Going deep into something like the Ethereum Virtual Machine is beyond the scope of this tutorial, but this question is critical if you want to better understand the backend you're building on. Instead of connecting to a specific server and reading from a database, we're reading from a distributed state machine. It's distributed because there are lots of nodes all over the world holding the same state. It's a state machine because it's in one state at any given time. We interact with it and compete with others using it to update a slice of its state that will get recorded before the next cycle of state updates.
 
-Putting these three lines together with our `connect` function, and understanding that our custom hook is already in use, our users should now be able to connect by clicking on the **Connect** button at the top right.
+Putting these three lines together with our `connect` function, and understanding that our custom hook is already in use, our users should now be able to connect by clicking on the **Connect Wallet** button at the top right.
 
-![Figure 4: Forget logins, now our users can connect to our app with their wallets!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/wallet.gif?raw=true)
+![Forget logins, now our users can connect to our app with their wallets!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/wallet.gif?raw=true)
 
 {% label %}
-Figure 4: Forget logins, now our users can connect to our app with their wallets!
+Forget logins, now our users can connect to our app with their wallets!
 
 ##### _Listing 2.1: Code for connecting a wallet_
 ```javascript
@@ -67,7 +65,7 @@ const connect = useCallback(async () => {
 
 # Challenge 🏋️
 
-Navigate to `context/web3Context.tsx` in your editor and follow the steps included as comments to finish writing the `Web3Provider` function. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 2.2](#listing-22-instructions-for-connecting-a-wallet) below.
+Navigate to `context/web3Context.tsx` in your code editor and follow the steps included as comments to finish writing the `Web3Provider` function. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 2.2](#listing-22-instructions-for-connecting-a-wallet) below.
 
 ##### _Listing 2.2: Instructions for connecting a wallet_
 ```javascript

--- a/mirror/03-create-post.md
+++ b/mirror/03-create-post.md
@@ -1,23 +1,21 @@
-# Step 3: Writing a Post
-
-Traditional blogs use databases to persist a post. An author might write some content and publish it, which triggers a create action on the server that writes the data to the database. The database would have schema that define the data structure. For instance, we might have a **posts** table with columns for post id, content, and author id.
+Traditional blogs use databases to persist an entry. An author might write some content and publish it, which triggers a create action on the server that writes the data to the database. The database would have schema that define the data structure. For instance, we might have a **entries** table with columns for entry id, content, and author id.
 
 The blockchain, however, is a bit different because it's decentralized. Rather than writing to a specific database, we'll be leveraging a distributed system that can't be controlled by a central authority.
   
-## Sustainable, Decentralized Storage 💾
+# Sustainable, Decentralized Storage 💾
 
 [Arweave](https://www.arweave.org/) is a decentralized network that allows users with extra storage space to provide that space as storage to the network in exchange for economic incentives. Users looking to store data in a decentralized, secure, censorship-resistant way, can leverage the network to do so. Effectively, Arweave is the storage part of the stack for dApps.
 
-Arwaeve uses a technology called "blockweaves" to achieve this. Similar to a blockchain, which connects transactions in a main chain across blocks, blockweaves are connected blocks that contain data. One of the main differences is that rather than connect blocks as a singly linked list, blockweaves are more like graphs.
+Arweave uses a technology called "blockweaves" to achieve this. Similar to a blockchain, which connects transactions in a main chain across blocks, blockweaves are connected blocks that contain data. One of the main differences is that rather than connect blocks as a singly linked list, blockweaves are more like graphs.
 
 This system requires a robust and sustainable economic structure to ensure storage providers are incentivized to replicate information forever at reasonable costs to the user. Basically, the user pays a small fee upfront to permanently store data. That fee is treated as principal that generates interest over time for storage providers.
 
 The architecture to achieve all this is beyond the scope of this tutorial, but if you're interested in going deeper, we recommend checking out the [Arweave yellow paper](https://www.arweave.org/yellow-paper.pdf).
 
-![Figure 5: Like this but decentralized...](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/storage.jpeg?raw=true)
+![Like this but decentralized...](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/storage.jpeg?raw=true)
 
 {% label %}
-Figure 5: Like this but decentralized...
+Like this but decentralized...
 
 # Implementation 🧩
 
@@ -26,7 +24,7 @@ There are several ways to interact with Arweave. In our case we're going to use 
 {% sidenote title="Box 3.1: What's a faucet?" %}
 Faucets are smart contracts that transfer a limited amount of tokens to users for testing purposes. Most protocols implement faucets to facilitate developers' testing and building efforts.
 
-## Arweave Wallet 👜
+# Arweave Wallet 👜
 
 Go to the [Arweave mainnet faucet](https://faucet.arweave.net/) and follow the instructions to create a wallet. Make sure you download the JSON file at the end of the process. Re-name that file to `arweave-wallet.json` and save it at the root of the project. You'll notice we have included this in the `.gitignore` to prevent exposing any private information.
 
@@ -36,33 +34,33 @@ Once you've saved the JSON file to the root, we should stop the local server in 
 $ ARWEAVE_WALLET=$(cat arweave-wallet.json) yarn dev
 ```
 
-## Posting to Arweave 📨
+# Posting to Arweave 📨
 
-With the Arweave wallet in place, we can now develop an endpoint to create posts. In `pages/api/arweave/post.ts`, we have a skeleton endpoint for us to add the Arweave write logic. You'll notice that we're passing in `req.body` which includes data and address fields. The data in this case will be the post's text and the address will be the author's public address.
+With the Arweave wallet in place, we can now develop an endpoint to create entries. In `pages/api/arweave/entry.ts`, we have a skeleton endpoint for us to add the Arweave write logic. You'll notice that we're passing in `req.body` which includes data and address fields. The data in this case will be the entry's text and the address will be the author's public address.
 
 First we need to initialize the wallet by using `JSON.parse`:
 
-```javascript
+```typescript
 const wallet = JSON.parse(process.env.ARWEAVE_WALLET as string);
 ```
 
 We should also instantiate a transaction by leveraging [Arweave's JavaScript library](https://github.com/ArweaveTeam/arweave-js) and passing in the data and the wallet.
 
-```javascript
+```typescript
 const transaction = await arweave.createTransaction({data: data}, wallet);
 ```
 
 Next, we'll want to add tags as the metadata that will associate the data with our dApp and with the author. We should also include a tag denoting the data as "application/json".
 
-```javascript
+```typescript
 transaction.addTag('App-Name', process.env.APP_NAME as string);
 transaction.addTag('Content-Type', 'application/json');
 transaction.addTag('Address', address);
 ```
 
-Then, we want to sign the transaction and post it to Arweave:
+Then, we want to sign the transaction and posty it to Arweave:
 
-```javascript
+```typescript
 await arweave.transactions.sign(transaction, wallet);
 await arweave.transactions.post(transaction);
 ```
@@ -71,17 +69,17 @@ You'll notice that Arweave's syntax is pretty straightforward. The only new aspe
 
 To finish the endpoint, we'll want to return the transaction id as part of the response:
 
-```javascript
+```typescript
 res.status(200).json(transaction.id);
 ```
 
-## Finishing the Form 📝
+# Finishing the Form 📝
 
-Now we need to make use of our post endpoint. To do that, we need to go to `components/CreatePostForm/CreatePostForm.tsx` and finish the `handleSubmit` function.
+Now we need to make use of our entry endpoint. To do that, we need to go to `components/CreateEntryForm/CreateEntryForm.tsx` and finish the `handleSubmit` function.
 
-In order to submit the Arweave transaction that creates the post, we can leverage axios and call the `post` endpoint we wrote above. We should pass in the data and address as part of the request body. And we should store the return value - the transaction id - in a variable as well since we'll need it later when we incorporate the NFT functionality.
+In order to submit the Arweave transaction that creates the entry, we can use [axios](https://axios-http.com/docs/intro) to call the `entry` endpoint we wrote above. We should pass in the data and address as part of the request body, and we should store the return value - the transaction id - in a variable as well. We'll need the transaction id later when we incorporate the NFT functionality into our dApp.
 
-```javascript
+```typescript
 const response = await axios.post(routes.api.arweave.post, {
   data,
   address,
@@ -90,13 +88,13 @@ const transactionId = response.data;
 console.log('transactionId: ', transactionId);
 ```
 
-With that our users are able to create entries that will live forever on the Arweave blockchain! You can create an entry yourself and confirm that the `transactionId` is printed in the console.
+With that complete, our users are able to create entries that will live forever on the Arweave blockchain! You can create an entry yourself and confirm that the `transactionId` is printed in the console.
 
-There's one issue though. Even though we can create an entry, we can't see it in our dApp yet. We'll address that shortly but first we need an endpoint to fetch posts. We'll tackle that next in Step 4.
+There's one issue though. Even though we can create an entry, we can't see it in our dApp yet. We'll address that shortly but first we need an endpoint to fetch entries. We'll tackle that next in Step 4.
 
-##### _Listing 3.1: Code for creating a post endpoint_
+##### _Listing 3.1: Code for creating a entry endpoint_
 
-```javascript
+```typescript
 export default async function (
   req: NextApiRequest,
   res: NextApiResponse<string>,
@@ -121,14 +119,14 @@ export default async function (
 }
 ```
 
-##### _Listing 3.2: Code for handling post submission_
+##### _Listing 3.2: Code for handling entry submission_
 
-```javascript
+```typescript
 if (provider && contract) {
   const data = createJsonMetaData(values);
 
   // Submit Arweave transaction
-  // Use axios to post data and address to api/arweave/post endpoint.
+  // Use axios to post data and address to api/arweave/entry endpoint.
   // This request should return transactionId
 
   // Mint NFT
@@ -146,11 +144,11 @@ if (provider && contract) {
 
 # Challenge 🏋️
 
-Navigate to `pages/api/arweave/post.ts` and `CreatePostForm.tsx` in your editor and follow the steps included as comments to finish writing the create post functionality. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 3.3](#listing-33-instructions-for-creating-a-post-endpoint) and [Listing 3.4](#listing-34-instructions-for-handling-post-submission) below.
+Navigate to `pages/api/arweave/entry.ts` and `components/CreateEntryForm/CreateEntryForm.tsx` in your editor and follow the steps included as comments to finish writing the create entry functionality. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 3.3](#listing-33-instructions-for-creating-a-entry-endpoint) and [Listing 3.4](#listing-34-instructions-for-handling-entry-submission) below.
 
-##### _Listing 3.3: Instructions for creating a post endpoint_
+##### _Listing 3.3: Instructions for creating a entry endpoint_
 
-```javascript
+```typescript
 export default async function (
   req: NextApiRequest,
   res: NextApiResponse<string>,
@@ -178,13 +176,13 @@ export default async function (
 }
 ```
 
-##### _Listing 3.4: Instructions for handling post submission_
+##### _Listing 3.4: Instructions for handling entry submission_
 
-```javascript
+```typescript
 if (provider && contract) {
   const data = createJsonMetaData(values);
   // Submit Arweave transaction
-  // Use axios to post data and address to api/arweave/post endpoint.
+  // Use axios to post data and address to api/arweave/entry endpoint.
   // This request should return transactionId
   alert('Entry created successfully');
 }

--- a/mirror/04-show-post.md
+++ b/mirror/04-show-post.md
@@ -1,14 +1,12 @@
-# Step 4: Fetching a Post
-
-The previous step left us hanging since we still having seen our post. Let's keep progressing by building an endpoint to retrieve a post.
+The previous step left us hanging, since we still have not seen our entry. Let's keep progressing by building an API endpoint to retrieve entries.
 
 # Implementation 🧩
 
-We first need to write another endpoint that will fetch a certain post for our application. We've structured the endpoint at `api/arweave/[transactionHash].ts` but we still need to write the core functionality.
+We first need to write another endpoint that will fetch a certain entry for our application. We've structured the endpoint at `pages/api/arweave/[transactionHash].ts`, but we still need to write the core functionality.
 
 Thinking about this endpoint, we should be able to pass in an identifier for a transaction and get the transaction data in response. We can do that by leveraging the `getData` method for Arweave transactions and we can parse the JSON it returns:
 
-```javascript
+```typescript
 const txDataResp = (await arweave.transactions.getData(
   transactionHash as string,
   {
@@ -22,13 +20,13 @@ const txData = JSON.parse(txDataResp);
 We should then check whether the transaction has been confirmed before sending a response to the client.
 
 {% sidenote title="Box 4.1: What does it mean for Arweave transactions to confirm?" %}
-As with any distributed system, there is a trade off between decentralized and speed. In order for the data to be stored, the Arweave protocol has to achieve consensus. You can read more about Arweave's consensus mechanism [here](https://arweave.medium.com/what-is-arweave-explain-like-im-five-425362144eb5) but suffice it to say that the lag most databases experience when writing data is exacerbated in distributed storage. That lag is amplified by the fact that data is not only being written but agreed upon across the protocol. This takes anywhere from 5-10 minutes at the time of writing.
+As with any distributed system, there is a trade off between speed and being decentralized. In order for the data to be stored, the Arweave protocol has to achieve consensus. You can read more about Arweave's consensus mechanism [here](https://arweave.medium.com/what-is-arweave-explain-like-im-five-425362144eb5) but suffice it to say that the lag most databases experience when writing data is exacerbated in distributed storage. That lag is amplified by the fact that data is not only being written but agreed upon across the protocol. This takes anywhere from 5-10 minutes at the time of writing.
 
-It will be clear why in Step 6 when we associate NFTs with each post but, as a preview, we wouldn't want users claiming NFTs before a post is actually created on Arweave.
+It will become clear why in Step 6 when we associate NFTs with each entry but, as a preview, we wouldn't want users claiming NFTs before an entry is actually created on Arweave.
 
-We should also note that you can choose how many confirmations a post should receive before considering it confirmed. For this template, we have set them in `constants.ts` through the `MIN_NUMBER_OF_CONFIRMATIONS` environment variable.
+Also note that you can choose how many confirmations an entry should receive before considering it confirmed. For this template, we have set them in `constants.ts` through the `MIN_NUMBER_OF_CONFIRMATIONS` environment variable.
 
-```javascript
+```typescript
 const txStatusResp = await arweave.transactions.getStatus(
   transactionHash as string,
 );
@@ -44,13 +42,13 @@ const txStatus =
 
 Once we've confirmed that our data has been written to Arweave, we can get the transaction by using its identifier from the query parameter `transactionHash`. 
 
-```javascript
+```typescript
 const tx = await arweave.transactions.get(transactionHash as string);
 ```
 
 We should also get the tags, so we have access to the user's address:
 
-```javascript
+```typescript
 const tags = {} as PostTagsT;
 (tx.get('tags') as any).forEach((tag) => {
   const key = tag.get('name', {decode: true, string: true});
@@ -58,17 +56,17 @@ const tags = {} as PostTagsT;
 });
 ```
 
-And we should get the block, so we have access to the post's timestamp:
+And we should get the block, so we have access to the entry's timestamp:
 
-```javascript
+```typescript
 const block = txStatusResp.confirmed
   ? await arweave.blocks.get(txStatusResp.confirmed.block_indep_hash)
   : null;
 ```
 
-With that, we have all the building blocks the client will need to display a post - post data, author, and timestamp. We can build the response and return it:
+With that, we have all the building blocks the client will need to display an entry - entry data, author, and timestamp. We can build the response and return it:
 
-```javascript
+```typescript
 res.status(200).json({
   id: transactionHash as string,
   data: txData,
@@ -78,15 +76,15 @@ res.status(200).json({
 });
 ```
 
-"But we still haven't displayed a post!", you yell. Yes, yes - we absolutely should do that. We'll get to that in Step 5.
+"But we still haven't displayed an entry!", you yell. Yes, yes - we absolutely should do that. We'll get to that in Step 5.
 
-![Figure 6: We're getting very close to some magic.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/map.jpeg?raw=true)
+![We're getting very close to some magic.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/map.jpeg?raw=true)
 
 {% label %}
-Figure 6: We're getting very close to some magic.
+We're getting very close to some magic.
 
 ##### _Listing 4.1: Code for fetching a post_
-```javascript
+```typescript
 const {transactionHash} = req.query;
 const txDataResp = (await arweave.transactions.getData(
   transactionHash as string,
@@ -135,10 +133,10 @@ if (txStatus === TransactionStatusE.CONFIRMED) {
 
 # Challenge 🏋️
 
-Navigate to `pages/api/arweave/[transactionHash].ts` in your editor and follow the steps included as comments to finish writing the endpoint to retrieve posts. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 4.2](#listing-42-instructions-for-fetching-a-post) below.
+Navigate to `pages/api/arweave/[transactionHash].ts` in your editor and follow the steps included as comments to finish writing the endpoint to retrieve entries. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 4.2](#listing-42-instructions-for-fetching-a-entry) below.
 
 ##### _Listing 4.2: Instructions for fetching a post_
-```javascript
+```typescript
 const {transactionHash} = req.query;
   // Get Arweave transaction data. Documentation can be found here: https://github.com/ArweaveTeam/arweave-js
 

--- a/mirror/05-display-posts.md
+++ b/mirror/05-display-posts.md
@@ -1,25 +1,23 @@
-# Step 5: Fetching a List of Posts
-
 If you've developed full stack apps on Web 2, you're probably familiar with the concept of a query builder. These libraries facilitate interactions with databases by creating a language-native API for database interactions that abstract the complexity of writing direct SQL.
 
-We're about to use a similar tool in Web 3. This step will require us to leverage [ArDB](https://www.npmjs.com/package/ardb) - a way to interact with Arweave with TypeScript without having to write GraphQL directly.
+We're about to use a similar tool in Web 3. This step will require us to leverage [ArDB](https://www.npmjs.com/package/ardb) - a way to interact with Arweave using Typescript, so we don't need to write GraphQL directly.
 
 # Implementation 🧩
 
-We'll start by opening the posts query endpoint file `api/arweave/search/[[query]].ts`. In this file we've started a function that will receive a query and return a list of posts. The goal is for the client to receive the list and display it so users can select a post to read.
+We'll start by opening the entries query endpoint file `pages/api/arweave/search/[[query]].ts`. In this file, we've started a function that will receive a query and return a list of entries. The goal is for the client to receive the list and display it, so users can select an entry to read.
 
-This endpoint should be flexible enough to handle requests for the most recent posts published on the application as well as the most recent posts published by a specific user.
+This endpoint should be flexible enough to handle requests for the most recent entries published on the application as well as the most recent entries published by a specific user.
 
-First we should instantiate an ardb instance, which we can do by confirming we've installed the relevant package and imported **ArDB** into this file. We should also create a `tags` variable with the app name.
+First we should instantiate an ArDB instance, which we can do by confirming we've installed the relevant package and imported **ArDB** into this file. We should also create a `tags` variable with the app name.
 
-```javascript
+```typescript
 const ardb = new ArDB(arweave);
 const tags = [{name: 'App-Name', values: [process.env.APP_NAME as string]}];
 ```
 
 Next we should retrieve the author's address from the `query` param if there is one and create another tag in the tags list:
 
-```javascript
+```typescript
 const searchAddress = query && query[0];
 
 if (searchAddress) {
@@ -27,27 +25,27 @@ if (searchAddress) {
 }
 ```
 
-With everything we need in place, we can leverage `ardb` to issue a search query for a transaction matching our `tags`. Similar to other query builders, we can chain methods to increase the specificity of the query. In this case, we'll want to find the latest 10 posts.
+With everything we need in place, we can leverage `ardb` to issue a search query for a transaction matching our `tags`. Similar to other query builders, we can chain methods to increase the specificity of the query. In this case, we'll want to find the latest 10 entries.
 
-```javascript
+```typescript
 const txs = await ardb.search('transactions').tags(tags).limit(10).find();
 ```
 
-Now everything is in place. If you refresh your dApp, you'll see the posts you created in the previous steps. Magic!
+Now everything is in place. If you refresh your dApp, you'll see the entries you created in the previous steps. Magic!
 
-![Figure 7: And all the posts simply... appear!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/magic.jpeg?raw=true)
+![And all the entries simply... appear!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/magic.jpeg?raw=true)
 
 {% label %}
-Figure 7: And all the posts simply... appear!
+And all the entries simply... appear!
 
-At this point, you'll be tempted to create an entry to test the functionality. And you absolutely should do that! But don't be alarmed when you click on the entry you just created and instead of getting the post, you get a message telling you it hasn't been confirmed yet.
+At this point, you'll be tempted to create an entry to test the functionality. And you absolutely should do that! But don't be alarmed when you click on the entry you just created and instead of getting the entry, you get a message telling you it hasn't been confirmed yet.
 
 Recall from Box 4.1 that distributed systems take a few minutes to come to consensus and confirm transactions. Keep making progress, and before you're done with Step 6, your entry will be ready to go.
 
-You'll also notice that if you click on a post, there's a warning in the NFT box with an error message. That's because we currently have a zero address as the default smart contract address. We'll fix that in Step 6.
+You'll also notice that if you click on an entry, there's a warning in the NFT box with an error message. That's because we currently have a zero address as the default smart contract address. We'll fix that in Step 6.
 
-##### _Listing 5.1: Code for fetching a list of posts_
-```javascript
+##### _Listing 5.1: Code for fetching a list of entries_
+```typescript
 try {
   const {query} = _req.query;
 
@@ -71,10 +69,10 @@ try {
 
 # Challenge 🏋️
 
-Navigate to `api/arweave/search/[[query]].ts` in your editor and follow the steps included as comments to finish writing the query endpoint. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 5.2](#listing-52-instructions-for-fetching-a-list-of-posts) below.
+Navigate to `api/arweave/search/[[query]].ts` in your editor and follow the steps included as comments to finish writing the query endpoint. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 5.2](#listing-52-instructions-for-fetching-a-list-of-entries) below.
 
-##### _Listing 5.2: Instructions for fetching a list of posts_
-```javascript
+##### _Listing 5.2: Instructions for fetching a list of entries_
+```typescript
 try {
   const {query} = _req.query;
 

--- a/mirror/06-mint-nft.md
+++ b/mirror/06-mint-nft.md
@@ -1,5 +1,3 @@
-# Step 6: Minting a Post NFT
-
 Non-fungible tokens (NFTs) are a fascinating technology enabled by the ledger capabilities of blockchain protocols. They allow us to prove ownership over digital assets by providing an ownership record that is decentralized and easy to verify.
 
 In our case we'll be leveraging a standard referred to as [ERC-721](https://ethereum.org/en/developers/docs/standards/tokens/erc-721/), which defines the basic functionality of an NFT. More importantly, there are standard smart contract implementations that we can leverage to minimize our work and ensure security.
@@ -7,7 +5,7 @@ In our case we'll be leveraging a standard referred to as [ERC-721](https://ethe
 {% sidenote title="Box 6.1: A note on smart contracts" %}
 Smart contracts are computer programs that run on certain blockchain protocols and can be executed to perform actions on the blockchain. They are deterministic and have specific, limited functionality designed to react to an input with certain predictable state changes. A common physical analogy are vending machines. You insert a predefined amount of money, and the machine drops a snack into a slot for you to pick up. Note that, as with many labels in crypto, the term smart contract can be a bit confusing since these are not smart in the intelligence sense of the word and they're certainly not legal contracts.
 
-## Development Tools 🛠
+# Development Tools 🛠
 
 We'll be leveraging [OpenZeppelin](https://openzeppelin.com/), a library of standard smart contracts that have been audited for security and are fully composable. As with any library or package you may have used before, this allows us to leverage off-the-shelf functionality and extend it if we need anything custom.
 
@@ -17,7 +15,7 @@ We'll be leveraging [OpenZeppelin](https://openzeppelin.com/), a library of stan
 
 If you navigate to `web3/contracts/MirrorClone.sol` you'll notice we have scaffolded a smart contract for you already. Before diving into the `createToken` function we need to write, let's dive into the general structure of the code.
 
-## Smart Contract Review 🧐
+# Smart Contract Review 🧐
 
 Solidity programs always start with the Solidity version at the top using the keyword `pragma`. This tells the compiler what version of Solidity to use.
 
@@ -25,7 +23,7 @@ In this case, we've also imported a few pre-built contracts from the OpenZeppeli
 
 You can think of the smart contract as a class with properties, a constructor, and methods. That maps pretty closely to the subsequent lines, which include defining the properties for our smart contract (e.g. a mapping called `tokenURIToTokenId`), setting up a constructor that takes in a name and symbol, and adding functions to extend the inherited functionality.
 
-## Creating Tokens 🏭
+# Creating Tokens 🏭
 
 Focusing on the `createToken` function, the first instruction tells us we need to make sure we are passing a `tokenURI` before creating a token. In this context, the token URI will be the transaction id, also known as the transaction hash, from Arweave.
 
@@ -35,16 +33,16 @@ We'll need to leverage Solidity's `require` function. If the requirement fails, 
 require(bytes(_tokenURI).length > 0, "Empty tokenURI");
 ```
 
-Next we should increment the counter for `tokenIds` so we can assign a unique token ID for each post.
+Next we should increment the counter for `tokenIds` so we can assign a unique token ID for each entry.
 
 ```solidity
 _tokenIds.increment();
 uint256 newItemId = _tokenIds.current();
 ```
 
-We can then leverage the `_safeMint` function we inherited from the **ERC721.sol contract** to create a token for the post's author. The intent will be for the dApp to immediately mint a post's NFT when the author clicks publish.
+We can then leverage the `_safeMint` function we inherited from the **ERC721.sol contract** to create a token for the entry's author. The intent will be for the dApp to immediately mint an entry's NFT when the author clicks publish.
 
-Once minted we should set the token's URI to link it to the post using the Arweave transaction hash. We should also add this relationship to our mapping tracker, `tokenURIToTokenId`, so we can later query NFTs by their token URI.
+Once minted we should set the token's URI to link it to the entry using the Arweave transaction hash. We should also add this relationship to our mapping tracker, `tokenURIToTokenId`, so we can later query NFTs by their token URI.
 
 Finally, we should emit an event that includes the author's address, the token ID and the token URI before the function returns the token ID.
 
@@ -58,7 +56,7 @@ emit TokenMinted(msg.sender, newItemId, _tokenURI);
 return newItemId;
 ```
 
-## Testing the Smart Contract 🧪
+# Testing the Smart Contract 🧪
 
 Smart contracts are no different than any other programs we write, so we should write tests to help us build robust contracts and provide a safety net for changes throughout development. We have already written 3 tests for you, and you can confirm they're passing by running:
 
@@ -88,17 +86,19 @@ MirrorClone
 
 If you uncomment the code again, everything will be nice and green.
 
-![Figure 8: Nice and green, just like we like it.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/green.jpeg?raw=true)
+![Nice and green, just the way we like it.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/green.jpeg?raw=true)
 
 {% label %}
-Figure 8: Nice and green, just like we like it.
+Nice and green, just the way we like it.
 
 Let's write one more test for the smart contract. In Solidity, mappings return 0 when a key doesn't have a value assigned to it. In other words, all keys exist with a default value of 0. We can write a test to make sure that any `tokenURI` that doesn't exist returns 0.
 
+Add the following test to `web3/test/index.test.ts` :
+
 ```javascript
 describe('tokenURIToTokenId', () => {
-  it('returns 0 if tokenURI does not exists', async () => {
-    expect(await contract.tokenURIToTokenId('ar://does-not-exists')).to.eq(
+  it('returns 0 if tokenURI does not exist', async () => {
+    expect(await contract.tokenURIToTokenId('ar://does-not-exist')).to.eq(
       0,
     );
   });
@@ -107,20 +107,20 @@ describe('tokenURIToTokenId', () => {
 
 Running the tests again should confirm all four tests are passing. 
 
-## Deploying the Smart Contract 🚀
+# Deploying the Smart Contract 🚀
 
-Now that we have a working smart contract that works as intended, we're ready to deploy. We're going to leverage the Polygon protocol to avoid the high gas fees on Ethereum. For our purposes Polygon works identically and is fully compatible with the Ethereum Virtual Machine.
+Now that we have a functional smart contract that works as intended, we're ready to deploy. We're going to leverage the Polygon protocol to avoid the high gas fees on Ethereum. For our purposes Polygon works identically and is fully compatible with the Ethereum Virtual Machine.
 
 Moreover, we're going to be deploying to Polygon's Mumbai testnet so you don't have to use valuable tokens to complete this dApp. In fact, if you were developing this for production, you'd deploy it to testnet first in order to test the functionality before deploying it to mainnet. Most production projects do that to make sure that mainnet deployments have been battle tested.
 
 {% sidenote title="Box 6.1: What's a testnet?" %}
 If you're unfamiliar with the concept of various networks, you can think of it as different environments for an app in Web 2 (e.g. development, test, production, etc). Most protocols have a mainnet blockchain for production deployments with real economic value, and a testnet for experimentation. The testnet matches the mainnet in functionality but doesn't manage economic value.
 
-In order to deploy the contract, we can use the `deploy.ts` file where the template provides us with a place to leverage **ethers** and **hardhat**. We can reference the `getContractFactory` to load the **MirrorClone** smart contract we just wrote. We can then use the `deploy` method passing in the name and the symbol as required by the `constructor`.
+In order to deploy the contract, we can use the `web3/scripts/deploy.ts` file where the template provides us with a place to leverage **ethers** and **hardhat**. We can reference the `getContractFactory` to load the **MirrorClone** smart contract we just wrote. We can then use the `deploy` method passing in the name and the symbol as required by the `constructor`.
 
 We can also include a console log that prints the smart contract public address, which we'll need to add as an environment variable shortly.
 
-```javascript
+```typescript
 const MirrorClone = await ethers.getContractFactory('MirrorClone');
 const mirrorClone = await MirrorClone.deploy('Mirror clone', 'MRM');
 
@@ -137,7 +137,7 @@ $ yarn web3:deploy:testnet
 
 The contract public address was logged to the console by our deployment script. Let's copy that and replace the default zeros in `.env.development` for the `NEXT_PUBLIC_CONTRACT_ADDRESS` environment variable. The dApp will leverage this when publishing entries to assign them NFTs.
 
-We'll need to restart the local server for the variable to reset:
+We'll need to restart the local server for the variable to reset. Stop the running server by pressing CTRL+C in the terminal where it is running:
 
 ```text
 $ ARWEAVE_WALLET=$(cat arweave-wallet.json) yarn dev
@@ -155,14 +155,14 @@ If the verification fails, double check your `PRIVATE_KEY` and `ETHERSCAN_API_KE
 
 If you visit [Polygonscan's testnet explorer](https://mumbai.polygonscan.com/), you can copy-paste the contract address from the command line into the search box and confirm the contract is on the blockchain!
 
-![Figure 9: If a contract deployment isn't reason for fireworks, I don't know what is. ](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/fireworks.jpeg?raw=true)
+![If a contract deployment isn't reason for fireworks, I don't know what is. ](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/fireworks.jpeg?raw=true)
 
 {% label %}
-Figure 9: If a contract deployment isn't reason for fireworks, I don't know what is.
+If a contract deployment isn't reason for fireworks, I don't know what is.
 
-## Minting NFTs for Posts 🍬
+# Minting NFTs for Entries 🍬
 
-Recall from Step 3 that we wrote a function that created posts in Arweave. We now need to integrate the NFT minting functionality into that workflow. If we return to `CreatePostForm.tsx`, we notice instructions at the bottom of the try block in `handleSubmit` for minting an NFT.
+Recall from Step 3 that we wrote a function that created entries in Arweave. We now need to integrate the NFT minting functionality into that workflow. If we return to `CreatePostForm.tsx`, we notice instructions at the bottom of the try block in `handleSubmit` for minting an NFT.
 
 We'll need to instantiate a signer and connect the contract to the signer. We'll then need to leverage the `createToken` function we just wrote to mint the NFT.
 
@@ -174,9 +174,9 @@ const resp = await contractWithSigner.createToken(transactionId);
 const rec = await resp.wait();
 ```
 
-If you try to create an entry now, your MetaMask wallet will ask you to sign a transaction to mint the NFT. After Arweave confirms the post, you'll be able to navigate to the post and see the NFT!
+If you try to create an entry now, your MetaMask wallet will ask you to sign a transaction to mint the NFT. After Arweave confirms the entry, you'll be able to navigate to the entry and see the NFT!
 
-But wouldn't it be nice if you could transfer that NFT to someone else? Perhaps someone wants to purchase the post from you or you want to gift ownership of the post to a friend. We'll tackle that next in Step 7.
+But wouldn't it be nice if you could transfer that NFT to someone else? Perhaps someone wants to purchase the entry from you or you want to gift ownership of the entry to a friend. We'll tackle that next in Step 7.
 
 ##### _Listing 6.1: Code for smart contract_
 ```javascript
@@ -208,8 +208,8 @@ function createToken(string memory _tokenURI) public returns (uint) {
 ##### _Listing 6.2: Code for tokenURIToTokenId test_
 ```javascript
 describe('tokenURIToTokenId', () => {
-  it('returns 0 if tokenURI does not exists', async () => {
-    expect(await contract.tokenURIToTokenId('ar://does-not-exists')).to.eq(
+  it('returns 0 if tokenURI does not exist', async () => {
+    expect(await contract.tokenURIToTokenId('ar://does-not-exist')).to.eq(
       0,
     );
   });
@@ -258,7 +258,7 @@ const handleSubmit = useCallback(
 
 # Challenge 🏋️
 
-Open `web3/contracts/MirrorClone.sol`, `index.test.ts`, `deploy.ts`, and `CreatePostForm.tsx` in your editor and follow the steps included as comments to finish writing the smart contract, its tests, the deploy script and the NFT minting functionality, respectively. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code blocks are also included in the listings below.
+Open `web3/contracts/MirrorClone.sol`, `index.test.ts`, `deploy.ts`, and `CreatePostForm.tsx` in your editor and follow the steps included as comments to finish writing the smart contract, its tests, the deploy script and the NFT minting functionality. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code blocks are also included in the listings below.
 
 ##### _Listing 6.5: Instructions for smart contract_
 ```javascript

--- a/mirror/07-transfer-nft.md
+++ b/mirror/07-transfer-nft.md
@@ -9,8 +9,6 @@ Hooray! No more walled gardens for data
 
 # Implementation 🧩
 
-# Transferring NFTs ♻️
-
 In order to make each entry's NFT transferable, we need to write a function that activates the blue **Transfer NFT** button shown on each entry's page. If we go to the `TransferNFTForm.tsx` component, we see a `handleSubmit` button with some simple instructions to connect the smart contract to signer, and to call `transferFrom` on the smart contract.
 
 Recall from Step 6 that we can instantiate a signer by calling `getSigner` on `provider`. Recall also that we can connect the `signer` to the `contract` as well, so we can use that code here to connect the smart contract and the signer at the top of `handleSubmit`:
@@ -19,6 +17,8 @@ Recall from Step 6 that we can instantiate a signer by calling `getSigner` on `p
 const signer = provider.getSigner();
 const contractWithSigner = contract.connect(signer);
 ```
+
+# Transferring an NFT ♻️
 
 Now all that's left is calling the `transferFrom` function in the contract. You might be wondering where that function is since we didn't write it in Step 6 when we finalized the `MirrorClone.sol` contract.
 

--- a/mirror/07-transfer-nft.md
+++ b/mirror/07-transfer-nft.md
@@ -1,34 +1,32 @@
-# Step 7: Transferring an NFT
-
-One of the key tenets of Web 3 is composability so you can think of this step as a precursor for a more advanced blog post marketplace. Maybe you or someone else wants to build a dApp that allows people to buy and sell blog post ownership.
+One of the key tenets of Web 3 is composability so you can think of this step as a precursor for a more advanced blog entry marketplace. Maybe you or someone else wants to build a dApp that allows people to buy and sell blog entry ownership.
 
 Because the Web 3 stack is decentralized, it means data no longer lives behind a walled garden where the app owners control access and own the data. In Web 3 users retain, not only ownership over the data, but the ability to port their data to other UIs that can access it directly from the blockchain.
 
-![Figure 10: Hooray! No more walled gardens for data](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/free.jpeg?raw=true)
+![Hooray! No more walled gardens for data](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/free.jpeg?raw=true)
 
 {% label %}
-Figure 10: Hooray! No more walled gardens for data
+Hooray! No more walled gardens for data
 
 # Implementation 🧩
 
-## Transferring NFTs ♻️
+# Transferring NFTs ♻️
 
-In order to make each post's NFT transferable, we need to write a function that activates the blue **Transfer NFT** button shown on each entry's page. If we go to the `TransferNFTForm.tsx` component, we see a `handleSubmit` button with some simple instructions to connect the smart contract to signer, and to call `transferFrom` on the smart contract.
+In order to make each entry's NFT transferable, we need to write a function that activates the blue **Transfer NFT** button shown on each entry's page. If we go to the `TransferNFTForm.tsx` component, we see a `handleSubmit` button with some simple instructions to connect the smart contract to signer, and to call `transferFrom` on the smart contract.
 
 Recall from Step 6 that we can instantiate a signer by calling `getSigner` on `provider`. Recall also that we can connect the `signer` to the `contract` as well, so we can use that code here to connect the smart contract and the signer at the top of `handleSubmit`:
 
-```javascript
+```typescript
 const signer = provider.getSigner();
 const contractWithSigner = contract.connect(signer);
 ```
 
 Now all that's left is calling the `transferFrom` function in the contract. You might be wondering where that function is since we didn't write it in Step 6 when we finalized the `MirrorClone.sol` contract.
 
-This is actually a standard function that comes from the ERC721 standard. We inherited the function from the standard contract, which means we can call it anytime even though we didn't explicitly write it in our contract. If you open `ERC721.sol`, you'll notice the function requires a from address, a to address, and a tokenId.
+The `transferFrom` function actually comes from the ERC721 standard. We inherited the function from the OpenZeppelin ERC721 contract, which means we can call it anytime even though we didn't explicitly write it in our contract. If you open `ERC721.sol`, you'll notice the function requires a from address, a to address, and a tokenId.
 
 We can complete the `handleSubmit` function by calling `transferFrom` on our `contractWithSigner`:
 
-```javascript
+```typescript
 const resp = await contractWithSigner.transferFrom(
   address,
   recipient,
@@ -43,10 +41,10 @@ With that in place, we can now test it by transferring the NFT. You should creat
 
 Once you do this, you'll have another public address controlled by your private key. Copy that address and paste it into the **Recipient Address** field. Then go back to your original account and click **Transfer NFT**.
 
-After accepting the transaction on MetaMask, your second account will own the post!
+After accepting the transaction on MetaMask, your second account will own the entry!
 
 ##### _Listing 7.1: Code for transferring an NFT_
-```javascript
+```typescript
 const handleSubmit = useCallback(
   .
   .
@@ -75,7 +73,7 @@ const handleSubmit = useCallback(
 Navigate to `TransferNFTForm.tsx` in your editor and follow the steps included as comments to finish writing the `handleSubmit` function for transferring NFTs. We include a description along with a link to the documentation you need to review in order to implement each line. The relevant code block is also included in [Listing 7.2](#listing-72-instructions-for-transferring-an-NFT) below.
 
 ##### _Listing 7.2: Instructions for transferring an NFT_
-```javascript
+```typescript
 const handleSubmit = useCallback(
   .
   .

--- a/mirror/08-conclusion.md
+++ b/mirror/08-conclusion.md
@@ -1,18 +1,16 @@
-# Conclusion 
-
 Congratulations! You've built a Web 3-native blog that resembles the functionality of [Mirror.xyz](https://mirror.xyz/).
 
 By leveraging a handful of protocols and tools like Polygon, Arweave, Hardhat, ethers.js, and ArDB, you were able to quickly build a full stack distributed application (dApp). In **Step 1** we leveraged a Next.js template to scaffold a simple application & we immediately got to work on turning it into a dApp. In **Step 2** we built functionality to connect to a user's MetaMask wallet.
 
-We then gave our users the ability to publish posts by sending data to Arweave in **Step 3**. Not only that but since Arweave stores data forever (or pretty much forever), we gave our users the ability to publish censorship-resistant, immutable posts over which they have full control.
+We then gave our users the ability to publish entries by sending data to Arweave in **Step 3**. Not only that but since Arweave stores data forever (or pretty much forever), we gave our users the ability to publish censorship-resistant, immutable entries over which they have full control.
 
-Expanding from write to read functionality, in **Step 4** we implemented the application's fetch function that retrieves data from Arweave by leveraging a transaction id and the address tag on our Arweave application deployment. This allowed us to display individual posts using the transaction id in the URI params.
+Expanding from write to read functionality, in **Step 4** we implemented the application's fetch function that retrieves data from Arweave by leveraging a transaction id and the address tag on our Arweave application deployment. This allowed us to display individual entries using the transaction id in the URI params.
 
-In **Step 5**, we implemented similar functions to fetch the last 10 posts and display them on the dApp's home page. By clicking on these, users call the functionality implemented in Step 4 to display individual posts.
+In **Step 5**, we implemented similar functions to fetch the last 10 entries and display them on the dApp's home page. By clicking on these, users call the functionality implemented in Step 4 to display individual entries.
 
-Not satisfied with a simple blog, and keen to explore the possibilities provided by leveraging the economics layer native to crypto rails, we established a smart contract to mint and manage NFTs for each post in **Step 6**. The contract automatically mints an NFT owned by the author when the post is published.
+Not satisfied with a simple blog, and keen to explore the possibilities provided by leveraging the economics layer native to crypto rails, we established a smart contract to mint and manage NFTs for each entry in **Step 6**. The contract automatically mints an NFT owned by the author when the entry is published.
 
-Finally, **Step 7** completed the NFT feature by giving users the ability to transfer their NFTs. An author can choose to transfer their post's NFT by clicking a button and providing the recipient's address. Thereafter, the NFT owner can do the same with any other user.
+Finally, **Step 7** completed the NFT feature by giving users the ability to transfer their NFTs. An author can choose to transfer their entry's NFT by clicking a button and providing the recipient's address. Thereafter, the NFT owner can do the same with any other user.
 
 In the process of building the blog, we learned how to connect a Web 3 wallet to effectively authenticate. We also expanded our understanding of Web 3 primitives like providers, signers and NFTs. 
 
@@ -24,10 +22,10 @@ The opportunities are endless and we wish you well on your journey!
 
 _If you want to connect with an amazing community of developers, join us on [Discord](https://figment.io/devchat)._
 
-![Figure 11: With ten miles behind me and ten thousand more to go…](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/hike.jpeg)
+![With ten miles behind me and ten thousand more to go…](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/hike.jpeg)
 ##### _Figure 11: With ten miles behind me and ten thousand more to go…_
 
-## Additional Resources 📚
+# Additional Resources 📚
 
 - [Arweave Overview](https://www.arweave.org/technology)
 - [Arweave Lightpaper](https://www.arweave.org/files/arweave-lightpaper.pdf)

--- a/mirror/08-conclusion.md
+++ b/mirror/08-conclusion.md
@@ -1,4 +1,6 @@
-Congratulations! You've built a Web 3-native blog that resembles the functionality of [Mirror.xyz](https://mirror.xyz/).
+# Wrapping up 🎁
+
+Congratulations! You've built a Web 3-native blog that resembles the functionality of [Mirror](https://mirror.xyz/).
 
 By leveraging a handful of protocols and tools like Polygon, Arweave, Hardhat, ethers.js, and ArDB, you were able to quickly build a full stack distributed application (dApp). In **Step 1** we leveraged a Next.js template to scaffold a simple application & we immediately got to work on turning it into a dApp. In **Step 2** we built functionality to connect to a user's MetaMask wallet.
 


### PR DESCRIPTION
- Edits to intro paragraph
- Edits to some headings
- All headings -> H1
- Replaced "post/posts" with "entry/entries" (except in the case of the `post` method!)
- Removed "Step X: " from headings
- Fix codeblocks (javascript -> typescript)
- Remove ".xyz" from links to Mirror
- Remove "Figure X: " from image labels

