### PR TITLE
fix images in Mirror Clone tutorial

### DIFF
--- a/mirror/00-mirror-intro.md
+++ b/mirror/00-mirror-intro.md
@@ -18,7 +18,7 @@ As always, we think of ourselves as your guide - for a brief amount of time - on
 
 We've tried to show you the door (or maybe part of it). Your job is to discover your path and walk it courageously.
 
-![“I do not believe it to be a matter of hope, it is simply a matter of time.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/matrix.jpeg?raw=true)
+![“I do not believe it to be a matter of hope, it is simply a matter of time.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/matrix.jpeg)
 
 {% label %}
 “I do not believe it to be a matter of hope, it is simply a matter of time.”
@@ -41,19 +41,19 @@ The entries will be saved on [Arweave](https://www.arweave.org/), a decentralize
 
 In **Step 2**, we'll introduce the [ethers.js](https://docs.ethers.io/) library and learn how to connect a user's MetaMask wallet to the dApp.
 
-![Screenshot of connecting wallet](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/connect.jpg?raw=true)
+![Screenshot of connecting wallet](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/connect.jpg)
 
 Then we'll introduce [Arweave](https://www.arweave.org/) - a decentralized, censorship resistant storage solution - in **Step 3**. We'll write an endpoint to create blog entries and finish a form to submit them. In **Step 4** we'll learn how to fetch them and in **Step 5** we'll write code to display a list of the latest entries.
 
-![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/entries.jpg?raw=true)
+![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/entries.jpg)
 
 **Step 6** will be a brief introduction to smart contracts including inheriting from standard libraries, writing functions, testing them and deploying the smart contract to the Polygon testnet. We'll be minting an NFT for each entry so authors can own their entries.
 
-![Screenshot of NFT](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/nft.jpg?raw=true)
+![Screenshot of NFT](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/nft.jpg)
 
 Finally, **Step 7** will implement functionality that allows authors to transfer NFTs. This sets up the application for expansion into a marketplace for blog entry ownership.
 
-![Screenshot of transfer](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/transfer.jpg?raw=true)
+![Screenshot of transfer](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/transfer.jpg)
 
 There are countless ways a dApp like this could be expanded. You could implement the NFT marketplace natively, or you might choose to implement a tipping button for readers who want to reward the writer.
 
@@ -63,7 +63,7 @@ At the end of the tutorial, we'll include a few [additional resources](https://l
 
 Let's get started!
 
-![All big things come from small beginnings](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/ladder.jpeg?raw=true)
+![All big things come from small beginnings](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/ladder.jpeg)
 
 {% label %}
 All big things come from small beginnings

--- a/mirror/01-mirror-setup.md
+++ b/mirror/01-mirror-setup.md
@@ -97,7 +97,7 @@ Feel free to explore the rest of the template on your own. It includes standard 
 
 Let's build!
 
-![“I can feel the anticipation.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/lego.jpeg?raw=true)
+![“I can feel the anticipation.”](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/lego.jpeg)
 
 {% label %}
 “I can feel the anticipation.”

--- a/mirror/02-connect-wallet.md
+++ b/mirror/02-connect-wallet.md
@@ -42,7 +42,7 @@ Going deep into something like the Ethereum Virtual Machine is beyond the scope 
 
 Putting these four lines together with our `connect` function and understanding that our custom hook is already in use, our users should now be able to connect by clicking on the **Connect Wallet** button at the top right.
 
-![Forget logins, now our users can connect to our app with their wallets!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/wallet.gif?raw=true)
+![Forget logins, now our users can connect to our app with their wallets!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/wallet.gif)
 
 {% label %}
 Forget logins, now our users can connect to our app with their wallets!
@@ -96,4 +96,4 @@ const connect = useCallback(async () => {
 
  Once you've completed the code, you will want to try connecting your MetaMask wallet by clicking on the **Connect Wallet** button in the top right corner of the screen:
 
- ![Screenshot of connecting wallet](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/connect.jpg?raw=true)
+ ![Screenshot of connecting wallet](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/connect.jpg)

--- a/mirror/03-create-entry.md
+++ b/mirror/03-create-entry.md
@@ -12,7 +12,7 @@ This system requires a robust and sustainable economic structure to ensure stora
 
 The architecture to achieve all this is beyond the scope of this tutorial, but if you're interested in going deeper, we recommend checking out the [Arweave yellow paper](https://www.arweave.org/yellow-paper.pdf).
 
-![Like this but decentralized...](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/storage.jpeg?raw=true)
+![Like this but decentralized...](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/storage.jpeg)
 
 {% label %}
 Like this but decentralized...
@@ -182,4 +182,4 @@ if (provider && contract) {
 
 Once you have completed the code, you will want to try out creating an entry by clicking on the **Create Entry** button on the Dashboard, then entering a title and some text.
 
-![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/entries.jpg?raw=true)
+![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/entries.jpg)

--- a/mirror/04-show-entry.md
+++ b/mirror/04-show-entry.md
@@ -78,7 +78,7 @@ res.status(200).json({
 
 "But we still haven't displayed an entry!", you yell. Yes, we absolutely should do that. We'll get to that in Step 5.
 
-![We're getting very close to some magic.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/map.jpeg?raw=true)
+![We're getting very close to some magic.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/map.jpeg)
 
 {% label %}
 We're getting very close to some magic.

--- a/mirror/05-display-entries.md
+++ b/mirror/05-display-entries.md
@@ -33,7 +33,7 @@ const txs = await ardb.search("transactions").tags(tags).limit(10).find();
 
 Now everything is in place. If you refresh your dApp, you'll see the entries you created in the previous steps. Magic!
 
-![And all the entries simply... appear!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/magic.jpeg?raw=true)
+![And all the entries simply... appear!](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/magic.jpeg)
 
 {% label %}
 And all the entries simply... appear!
@@ -97,4 +97,4 @@ try {
 
 Once the code is complete, you will be able to see a list of posts on the Dashboard as well as under your user profile:
 
-![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/entries.jpg?raw=true)
+![Screenshot displaying a list of entries](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/entries.jpg)

--- a/mirror/06-mint-nft.md
+++ b/mirror/06-mint-nft.md
@@ -86,7 +86,7 @@ MirrorClone
 
 If you uncomment the code again, everything will be nice and green.
 
-![Nice and green, just the way we like it.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/green.jpeg?raw=true)
+![Nice and green, just the way we like it.](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/green.jpeg)
 
 {% label %}
 Nice and green, just the way we like it.
@@ -167,7 +167,7 @@ Nothing to worry about! This simply means that the exact bytecode for the smart 
 
 If you visit [Polygonscan's testnet explorer](https://mumbai.polygonscan.com/), you can copy-paste the contract address from the command line into the search box and confirm the contract is on the blockchain.
 
-![If a contract deployment isn't reason for fireworks, I don't know what is. ](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/fireworks.jpeg?raw=true)
+![If a contract deployment isn't reason for fireworks, I don't know what is. ](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/fireworks.jpeg)
 
 {% label %}
 If a contract deployment isn't reason for fireworks, I don't know what is.
@@ -333,4 +333,4 @@ const handleSubmit = useCallback(
 
 Once you have completed the code, creating an entry will mint it as an NFT automatically (once you've confirmed the transaction in MetaMask):
 
-![Screenshot of NFT](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/nft.jpg?raw=true)
+![Screenshot of NFT](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/nft.jpg)

--- a/mirror/07-transfer-nft.md
+++ b/mirror/07-transfer-nft.md
@@ -2,7 +2,7 @@ One of the key tenets of Web 3 is composability, so you can think of this step a
 
 Because the Web 3 stack is decentralized, it means data no longer lives behind a walled garden where the app owners control access and own the data. In Web 3 users retain not only ownership over the data, but the ability to port their data to other UIs that can access it directly from the blockchain.
 
-![Hooray! No more walled gardens for data](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/free.jpeg?raw=true)
+![Hooray! No more walled gardens for data](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/free.jpeg)
 
 {% label %}
 Hooray! No more walled gardens for data
@@ -90,4 +90,4 @@ const handleSubmit = useCallback(
 
 Once you have completed the code, you can try transferring an entry NFT by pasting the address of the account you want to transfer the NFT to into the textinput, then clicking on **Transfer NFT** and confirming the transaction in MetaMask:
 
-![Screenshot of transfer](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/transfer.jpg?raw=true)
+![Screenshot of transfer](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/transfer.jpg)

--- a/mirror/08-conclusion.md
+++ b/mirror/08-conclusion.md
@@ -24,7 +24,7 @@ The opportunities are endless and we wish you well on your journey!
 
 _If you want to connect with an amazing community of developers, join us on [Discord](https://figment.io/devchat)._
 
-![With ten miles behind me and ten thousand more to go…](https://raw.githubusercontent.com/figment-networks/learn-tutorials/mirror-tutorial/mirror/assets/hike.jpeg?raw=true)
+![With ten miles behind me and ten thousand more to go…](https://raw.githubusercontent.com/figment-networks/learn-tutorials/master/mirror/assets/hike.jpeg)
 
 {% label %}
 With ten miles behind me and ten thousand more to go…


### PR DESCRIPTION
Recently one of our community members brought this to our attention that most of the images in the Mirror Clone tutorial are not showing due to broken links. This PR is to fix those broken image links.
I suspect it happened because earlier images were linked to a different branch that no longer exists.